### PR TITLE
append "/" to directory paths omitting it

### DIFF
--- a/lib/cohttp/cohttp-eio/src/cohttp_eio.mli
+++ b/lib/cohttp/cohttp-eio/src/cohttp_eio.mli
@@ -81,6 +81,8 @@ module Server : sig
   val bad_request_response : response
   (* [bad_request t] returns a HTTP/1.1, 400 status response. *)
 
+  val respond_redirect : uri:Uri.t -> response
+
   (** {1 Run Server} *)
 
   val run :

--- a/lib/cohttp/cohttp-eio/src/dune
+++ b/lib/cohttp/cohttp-eio/src/dune
@@ -1,4 +1,4 @@
 (library
  (name cohttp_eio)
  (public_name cohttp-eio)
- (libraries eio http fmt))
+ (libraries eio uri http fmt))

--- a/lib/cohttp/cohttp-eio/src/server.ml
+++ b/lib/cohttp/cohttp-eio/src/server.ml
@@ -65,6 +65,10 @@ let internal_server_error_response =
 let bad_request_response =
   (Http.Response.make ~status:`Bad_request (), Body.Empty)
 
+let respond_redirect ~uri =
+  let headers = Http.Header.init_with "location" (Uri.to_string uri) in
+  (Http.Response.make ~headers ~status:`Moved_permanently (), Body.Empty)
+
 let write_response ?request writer (response, body) =
   let headers =
     let request_meth = Option.map Http.Request.meth request in

--- a/src/main.ml
+++ b/src/main.ml
@@ -38,10 +38,13 @@ let serve ~docroot ~uri path =
     match Eio.File.((stat fin).kind) with
     |`Directory -> begin
        let idx = Eio.Path.(fname / "index.html") in
-       if Eiox.file_exists idx then
-          Server.html_response (Eio.Path.load idx)
+       (* if path doesn't end in /, redirect appending / *)
+       if String.length path > 1 && path.[(String.length path) - 1] != '/' then
+         Server.respond_redirect ~uri:(Uri.of_string ((Uri.to_string uri) ^ "/"))
+       else if Eiox.file_exists idx then
+         Server.html_response (Eio.Path.load idx)
        else
-          Server.html_response "not found"
+         Server.html_response "not found"
     end
     |`Regular_file ->
        (* TODO stream body instead of loading *)


### PR DESCRIPTION
E.g. if accessing "/directory", we'll get redirected with a 301 to "/directory/".

This means relative paths inside this directory will work from 'index.html'.